### PR TITLE
Improve immediatelyResponse logic for Slf, SlfSwitch, Suf

### DIFF
--- a/accessories/AccessoryBase.js
+++ b/accessories/AccessoryBase.js
@@ -9,6 +9,7 @@ class AccessoryBase {
     this.nlType = accessory.context.NooLite.type;
     this.nlChannel = accessory.context.NooLite.channel;
     this.nlId = accessory.context.NooLite.id;
+    this.state = {};
 
     return this.init();
   }

--- a/accessories/Slf.js
+++ b/accessories/Slf.js
@@ -15,20 +15,22 @@ class Slf extends AccessoryBase {
   }
 
   createPeriodicTasks() {
-    super.initOrCreateServices();
-    if (this.platform.periodicAccessoryUpdate) {
-      setInterval(() => {
-        this.log('send periodically update command');
-        let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
-        this.platform.sendCommand(command, (err, nlRes) => {})
-      }, this.platform.periodicAccessoryUpdate * 1000);
-    }
+    if (!this.platform.periodicAccessoryUpdate) return;
+
+    setInterval(() => {
+      this.log('send periodically update command');
+      const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
+      this.platform.sendCommand(command, () => {});
+    }, this.platform.periodicAccessoryUpdate * 1000);
   }
 
   initOrCreateServices() {
     super.initOrCreateServices();
 
-    let onCharacteristic = this.getOrCreateService(this.platform.Service.Lightbulb).getCharacteristic(this.platform.Characteristic.On);
+    const onCharacteristic = this.getOrCreateService(this.platform.Service.Lightbulb).getCharacteristic(this.platform.Characteristic.On);
+
+    this.state.on = onCharacteristic.value || false;
+
     onCharacteristic
       .on('set', this.setOnState.bind(this))
       .on('get', this.getOnState.bind(this));
@@ -46,10 +48,10 @@ class Slf extends AccessoryBase {
         //      2 – временное включение
         // d3 - Текущая яркость (0-255)
 
-        let onValue = nlCmd.d2 > 0;
+        this.state.on = nlCmd.d2 > 0;
 
-        if (onCharacteristic.value !== onValue) {
-            onCharacteristic.updateValue(onValue);
+        if (onCharacteristic.value !== this.state.on) {
+            onCharacteristic.updateValue(this.state.on);
         }
       }
     });
@@ -57,38 +59,28 @@ class Slf extends AccessoryBase {
 
   getOnState(callback) {
     this.log("get value");
-    let acc = this.accessory;
-
-    let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
     
     if (this.platform.immediatelyResponse){
-      callback(null, acc.value);
+      return callback(null, this.state.on);
     }
 
+    const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
     this.platform.sendCommand(command, (err, nlRes) => {
       if (err) {
         this.log('Error on write: ', err.message);
-        if (!this.platform.immediatelyResponse){
-          callback(new Error('Error on write'));
-        }
-        return;
+        return callback(new Error('Error on write'));
       } else if (nlRes.isError()) {
         this.log('Error on response: ', nlRes);
-        if (!this.platform.immediatelyResponse){
-          callback(new Error('Error on response'));
-        }
-        return;
+        return callback(new Error('Error on response'));
       }
 
-      let onValue = acc.value;
+      let onValue = this.state.on;
 
       if (nlRes.isState() && nlRes.fmt === 0) {
         onValue = nlRes.d2 > 0;
       }
-      if (!this.platform.immediatelyResponse){
-        callback(null, onValue);  
-      }
-      
+
+      return callback(null, onValue);        
     })
 
   }

--- a/accessories/SlfSwitch.js
+++ b/accessories/SlfSwitch.js
@@ -15,20 +15,22 @@ class SlfSwitch extends AccessoryBase {
   }
 
   createPeriodicTasks() {
-    super.initOrCreateServices();
-    if (this.platform.periodicAccessoryUpdate) {
-      setInterval(() => {
-        this.log('send periodically update command');
-        let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
-        this.platform.sendCommand(command, (err, nlRes) => {})
-      }, this.platform.periodicAccessoryUpdate * 1000);
-    }
+    if (!this.platform.periodicAccessoryUpdate) return;
+
+    setInterval(() => {
+      this.log('send periodically update command');
+      const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
+      this.platform.sendCommand(command, () => {})
+    }, this.platform.periodicAccessoryUpdate * 1000);
   }
 
   initOrCreateServices() {
     super.initOrCreateServices();
 
-    let onCharacteristic = this.getOrCreateService(this.platform.Service.Switch).getCharacteristic(this.platform.Characteristic.On);
+    const onCharacteristic = this.getOrCreateService(this.platform.Service.Switch).getCharacteristic(this.platform.Characteristic.On);
+    
+    this.state.on = onCharacteristic.value || false;
+    
     onCharacteristic
       .on('set', this.setOnState.bind(this))
       .on('get', this.getOnState.bind(this));
@@ -46,10 +48,10 @@ class SlfSwitch extends AccessoryBase {
         //      2 – временное включение
         // d3 - Текущая яркость (0-255)
 
-        let onValue = nlCmd.d2 > 0;
+        this.state.on = nlCmd.d2 > 0;
 
-        if (onCharacteristic.value !== onValue) {
-            onCharacteristic.updateValue(onValue);
+        if (onCharacteristic.value !== this.state.on) {
+            onCharacteristic.updateValue(this.state.on);
         }
       }
     });
@@ -57,38 +59,28 @@ class SlfSwitch extends AccessoryBase {
 
   getOnState(callback) {
     this.log("get value");
-    let acc = this.accessory;
-
-    let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
     
     if (this.platform.immediatelyResponse){
-      callback(null, acc.value);
+      return callback(null, this.state.on);
     }
 
+    const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
     this.platform.sendCommand(command, (err, nlRes) => {
       if (err) {
         this.log('Error on write: ', err.message);
-        if (!this.platform.immediatelyResponse){
-          callback(new Error('Error on write'));
-        }
-        return;
+        return callback(new Error('Error on write'));
       } else if (nlRes.isError()) {
         this.log('Error on response: ', nlRes);
-        if (!this.platform.immediatelyResponse){
-          callback(new Error('Error on response'));
-        }
-        return;
+        return callback(new Error('Error on response'));
       }
 
-      let onValue = acc.value;
+      let onValue = this.state.on;
 
       if (nlRes.isState() && nlRes.fmt === 0) {
         onValue = nlRes.d2 > 0;
       }
 
-      if (!this.platform.immediatelyResponse){
-        callback(null, onValue);  
-      }
+      return callback(null, onValue);  
     })
 
   }

--- a/accessories/Suf.js
+++ b/accessories/Suf.js
@@ -15,27 +15,31 @@ class Suf extends AccessoryBase {
   }
 
   createPeriodicTasks() {
-    super.initOrCreateServices();
-    if (this.platform.periodicAccessoryUpdate) {
-      setInterval(() => {
-        this.log('send periodically update command');
-        let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
-        this.platform.sendCommand(command, (err, nlRes) => {})
-      }, this.platform.periodicAccessoryUpdate * 1000);
-    }
+    if (!this.platform.periodicAccessoryUpdate) return;
+    
+    setInterval(() => {
+      this.log('send periodically update command');
+      const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
+      this.platform.sendCommand(command, (err, nlRes) => {})
+    }, this.platform.periodicAccessoryUpdate * 1000);
   }
 
   initOrCreateServices() {
     super.initOrCreateServices();
 
-    let lightbulb = this.getOrCreateService(this.platform.Service.Lightbulb);
-
-    let onCharacteristic = lightbulb.getCharacteristic(this.platform.Characteristic.On);
+    const lightbulb = this.getOrCreateService(this.platform.Service.Lightbulb);
+    const onCharacteristic = lightbulb.getCharacteristic(this.platform.Characteristic.On);
+    
+    this.state.on = onCharacteristic.value || false;
+    
     onCharacteristic
       .on('set', this.setOnState.bind(this))
       .on('get', this.getOnState.bind(this));
 
-    let brightness = lightbulb.getCharacteristic(this.platform.Characteristic.Brightness);
+    const brightness = lightbulb.getCharacteristic(this.platform.Characteristic.Brightness);
+
+    this.state.brightness = brightness.value || false;
+
     brightness
       .on('set', this.setBrightnessState.bind(this))
       .on('get', this.getBrightnessState.bind(this));
@@ -53,22 +57,22 @@ class Suf extends AccessoryBase {
         //      2 – временное включение
         // d3 - Текущая яркость (0-255)
 
-        let onValue = nlCmd.d2 > 0;
+        this.state.on = nlCmd.d2 > 0;
 
-        if (onCharacteristic.value !== onValue) {
-          onCharacteristic.updateValue(onValue);
+        if (onCharacteristic.value !== this.state.on) {
+          onCharacteristic.updateValue(this.state.on);
         }
 
-        let currentBrightness = this.valueConverter(nlCmd.d3, 255, 100);
+        this.state.brightness = this.valueConverter(nlCmd.d3, 255, 100);
 
-        if (currentBrightness > 100) {
-          currentBrightness = 100;
-        } else if (currentBrightness < 0) {
-          currentBrightness = 0;
+        if (this.state.brightness > 100) {
+          this.state.brightness = 100;
+        } else if (this.state.brightness < 0) {
+          this.state.brightness = 0;
         }
 
-        if (brightness.value !== currentBrightness) {
-          brightness.updateValue(currentBrightness)
+        if (brightness.value !== this.state.brightness) {
+          brightness.updateValue(this.state.brightness)
         }
       }
     });
@@ -76,38 +80,28 @@ class Suf extends AccessoryBase {
 
   getOnState(callback) {
     this.log("get value");
-    let acc = this.accessory;
-
-    let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
 
     if (this.platform.immediatelyResponse){
-      callback(null, acc.value);
+      return callback(null, this.state.on);
     }
 
+    const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
     this.platform.sendCommand(command, (err, nlRes) => {
       if (err) {
         this.log('Error on write: ', err.message);
-        if (!this.platform.immediatelyResponse){
-          callback(new Error('Error on write'));
-        }
-        return;
+        return callback(new Error('Error on write'));
       } else if (nlRes.isError()) {
         this.log('Error on response: ', nlRes);
-        if (!this.platform.immediatelyResponse){
-          callback(new Error('Error on response'));
-        }
-        return;
+        return callback(new Error('Error on response'));
       }
 
-      let onValue = acc.value;
+      let onValue = this.state.on;
 
       if (nlRes.isState() && nlRes.fmt === 0) {
         onValue = nlRes.d2 > 0;
       }
 
-      if (!this.platform.immediatelyResponse){
-        callback(null, onValue);  
-      }
+      return callback(null, onValue);  
     })
 
   }
@@ -135,26 +129,25 @@ class Suf extends AccessoryBase {
 
   getBrightnessState(callback) {
     this.log("get brightness value");
-    let acc = this.accessory;
-    let self = this;
 
-    let command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
+    if (this.platform.immediatelyResponse) {
+      return callback(null, this.state.brightness);
+    }
 
+    const command = new NooLiteRequest(this.nlChannel, 128, 2, 0, 0, 0, 0, 0, 0, 0, ...this.nlId.split(':'));
     this.platform.sendCommand(command, (err, nlRes) => {
       if (err) {
         this.log('Error on write: ', err.message);
-        callback(new Error('Error on write'));
-        return;
+        return callback(new Error('Error on write'));
       } else if (nlRes.isError()) {
         this.log('Error on response: ', nlRes);
-        callback(new Error('Error on response'));
-        return;
+        return callback(new Error('Error on response'));
       }
 
-      let brightnessValue = acc.value;
+      let brightnessValue = this.state.brightness;
 
       if (nlRes.isState() && nlRes.fmt === 0) {
-        brightnessValue = self.valueConverter(nlRes.d3, 255, 100);
+        brightnessValue = this.valueConverter(nlRes.d3, 255, 100);
         if (brightnessValue > 100) {
           brightnessValue = 100;
         } else if (brightnessValue < 0) {
@@ -162,7 +155,7 @@ class Suf extends AccessoryBase {
         }
       }
 
-      callback(null, brightnessValue);
+      return callback(null, brightnessValue);
     })
 
   }

--- a/index.js
+++ b/index.js
@@ -45,8 +45,13 @@ class NooLitePlatform {
     let serverPort = config['serverPort'] || 8080,
         serialPort = config['serialPort'];
 
-    this.periodicAccessoryUpdate = parseInt(config['periodicAccessoryUpdate']);
     this.immediatelyResponse = config['immediatelyResponse'] || false;
+    this.periodicAccessoryUpdate = parseInt(config['periodicAccessoryUpdate']);
+
+    // Use default periodicAccessoryUpdate if immediatelyResponse is specified and no periodicAccessoryUpdate provided
+    if (this.immediatelyResponse && !this.periodicAccessoryUpdate) {
+      this.periodicAccessoryUpdate = 5;
+    }
     
     // Initialize
     this.AccessoryUtil = new AccessoryUtil(platform);


### PR DESCRIPTION
After testing with 27 Slf devices it turned out that МТRF-64 can't handle large queues fast enough. It would require ~10 seconds to receive status from all accessories just to update state when opening HomeKit or HomeBridge accessory pages. This pull request changes **immediatelyResponse** behaviour.

**immediatelyResponse** now requires **periodicAccessoryUpdate** and uses default value if not provided
**getOnState** and **getBrightnessState** now:
*  returns cached value (from inner state) when immediatelyResponse is specified
* calls callback only once (calling callback multiple times is not an expected behaviour i believe)
* doesn't send command when immediatelyResponse is specified